### PR TITLE
feat: Add page for module test data

### DIFF
--- a/Front/app/serve.log
+++ b/Front/app/serve.log
@@ -1,5 +1,0 @@
-
-> app@0.1.0 serve
-> vue-cli-service serve
-
- INFO  Starting development server...

--- a/Front/app/src/components/DataEditor.vue
+++ b/Front/app/src/components/DataEditor.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="data-editor p-4 border border-gray-300 dark:border-gray-700 rounded-lg">
+    <h2 class="text-2xl font-bold mb-4">Edit Data</h2>
+    <form @submit.prevent="saveData">
+      <div v-for="(value, key) in editableData" :key="key" class="mb-4">
+        <label :for="key" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{ key }}</label>
+        <input v-if="typeof value === 'string' || typeof value === 'number'" type="text" :id="key" v-model="editableData[key]" class="mt-1 block w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+        <textarea v-else-if="typeof value === 'object'" :id="key" v-model="editableData[key]" rows="5" class="mt-1 block w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"></textarea>
+      </div>
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">Save</button>
+    </form>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'DataEditor',
+  props: {
+    data: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      editableData: {},
+    };
+  },
+  watch: {
+    data: {
+      immediate: true,
+      handler(newData) {
+        // Deep clone the data to avoid modifying the original object directly
+        this.editableData = JSON.parse(JSON.stringify(newData));
+        // Stringify object/array fields for editing in textarea
+        for (const key in this.editableData) {
+          if (typeof this.editableData[key] === 'object' && this.editableData[key] !== null) {
+            this.editableData[key] = JSON.stringify(this.editableData[key], null, 2);
+          }
+        }
+      },
+    },
+  },
+  methods: {
+    saveData() {
+        const dataToSave = { ...this.editableData };
+        for (const key in dataToSave) {
+            try {
+                // Try to parse fields that were stringified
+                dataToSave[key] = JSON.parse(dataToSave[key]);
+            } catch (e) {
+                // Keep as string if not valid JSON
+            }
+        }
+        this.$emit('save', dataToSave);
+    },
+  },
+};
+</script>

--- a/Front/app/src/components/ModuleData.vue
+++ b/Front/app/src/components/ModuleData.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="module-data p-8">
+    <h1 class="text-3xl font-bold mb-6">Test Data for {{ $route.params.id }}</h1>
+    <div v-if="loading" class="text-gray-600 dark:text-gray-400">Loading...</div>
+    <div v-if="error" class="text-red-500">{{ error }}</div>
+    <div class="flex space-x-8">
+      <ul v-if="testData.length" class="w-1/3 space-y-4">
+        <li v-for="item in testData" :key="item.id" @click="selectDataItem(item)" :class="['cursor-pointer block p-4 rounded-lg', selectedItem && selectedItem.id === item.id ? 'bg-blue-200 dark:bg-blue-900' : 'bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700']">
+          <h2 class="text-xl font-semibold">{{ item.id }}</h2>
+        </li>
+      </ul>
+      <div v-if="selectedItem" class="w-2/3">
+        <DataEditor :data="selectedItem" @save="handleSave" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+import DataEditor from './DataEditor.vue';
+
+export default {
+  name: 'ModuleData',
+  components: {
+    DataEditor,
+  },
+  data() {
+    return {
+      testData: [],
+      selectedItem: null,
+      loading: true,
+      error: null,
+    };
+  },
+  async created() {
+    await this.fetchTestData();
+  },
+  methods: {
+    async fetchTestData() {
+      this.loading = true;
+      this.error = null;
+      const moduleId = this.$route.params.id;
+      try {
+        const response = await axios.get(`/api/modules/${moduleId}/test-data`, {
+          headers: {
+            'Authorization': `Bearer ${localStorage.getItem('api_token')}`
+          }
+        });
+        this.testData = response.data;
+      } catch (err) {
+        this.error = 'Failed to load test data.';
+        console.error(err);
+      } finally {
+        this.loading = false;
+      }
+    },
+    selectDataItem(item) {
+      this.selectedItem = item;
+    },
+    async handleSave(updatedData) {
+      const moduleId = this.$route.params.id;
+      const dataId = this.selectedItem.id;
+      try {
+        await axios.put(`/api/modules/${moduleId}/test-data/${dataId}`, updatedData, {
+          headers: {
+            'Authorization': `Bearer ${localStorage.getItem('api_token')}`
+          }
+        });
+        // Refresh data after save
+        await this.fetchTestData();
+        // Optionally, show a success message
+        alert('Data saved successfully!');
+      } catch (err) {
+        this.error = 'Failed to save data.';
+        console.error(err);
+        alert('Error saving data.');
+      }
+    },
+  },
+};
+</script>

--- a/Front/app/src/components/ModulesList.vue
+++ b/Front/app/src/components/ModulesList.vue
@@ -1,12 +1,44 @@
 <template>
   <div class="modules-list p-8">
     <h1 class="text-3xl font-bold mb-6">Modules</h1>
-    <p class="text-gray-600 dark:text-gray-400">Modules list will be implemented here.</p>
+    <div v-if="loading" class="text-gray-600 dark:text-gray-400">Loading...</div>
+    <div v-if="error" class="text-red-500">{{ error }}</div>
+    <ul v-if="modules.length" class="space-y-4">
+      <li v-for="module in modules" :key="module.id">
+        <router-link :to="`/modules/${module.id}/test-data`" class="block p-4 bg-gray-100 dark:bg-gray-800 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700">
+          <h2 class="text-xl font-semibold">{{ module.name }}</h2>
+        </router-link>
+      </li>
+    </ul>
   </div>
 </template>
 
 <script>
+import axios from 'axios';
+
 export default {
-  name: 'ModulesList'
-}
+  name: 'ModulesList',
+  data() {
+    return {
+      modules: [],
+      loading: true,
+      error: null,
+    };
+  },
+  async created() {
+    try {
+      const response = await axios.get('/api/modules', {
+        headers: {
+          'Authorization': `Bearer ${localStorage.getItem('api_token')}`
+        }
+      });
+      this.modules = response.data;
+    } catch (err) {
+      this.error = 'Failed to load modules.';
+      console.error(err);
+    } finally {
+      this.loading = false;
+    }
+  },
+};
 </script>

--- a/Front/app/src/router/index.js
+++ b/Front/app/src/router/index.js
@@ -4,6 +4,7 @@ import CommandList from '../components/CommandList.vue'
 import EventsList from '../components/EventsList.vue'
 import SettingsPage from '../components/Settings.vue'
 import ModulesList from '../components/ModulesList.vue'
+import ModuleData from '../components/ModuleData.vue'
 import ModuleSettings from '../components/ModuleSettings.vue'
 import LoginAuth from '../components/LoginAuth.vue'
 import AuthCallback from '../components/AuthCallback.vue'
@@ -43,6 +44,11 @@ const routes = [
     path: '/modules',
     name: 'ModulesList',
     component: ModulesList
+  },
+  {
+    path: '/modules/:id/test-data',
+    name: 'ModuleData',
+    component: ModuleData
   },
   {
     path: '/module/:id/settings',

--- a/SelfApi/routes/get-modules.js
+++ b/SelfApi/routes/get-modules.js
@@ -1,0 +1,62 @@
+const BOTS = require('../../Class/BOTS.js');
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+    path: /^\/modules(\/([^\/]+)(\/test-data(\/([^\/]+))?)?)?$/,
+    method: 'get',
+    handler: async (req, res, bot, user, app) => {
+        const [, , moduleId, , dataId] = req.path.match(/^\/modules(\/([^\/]+)(\/test-data(\/([^\/]+))?)?)?$/);
+
+        const modulesPath = path.join(__dirname, '../../Modules');
+
+        if (!moduleId) {
+            // /modules - List all modules
+            try {
+                const moduleDirs = await fs.promises.readdir(modulesPath, { withFileTypes: true });
+                const modules = moduleDirs
+                    .filter(dirent => dirent.isDirectory())
+                    .map(dirent => ({ id: dirent.name, name: dirent.name }));
+                return res.json(modules);
+            } catch (error) {
+                console.error("Error reading modules directory:", error);
+                return res.status(500).json({ message: "Error reading modules directory" });
+            }
+        }
+
+        const modulePath = path.join(modulesPath, moduleId);
+        const dataTestPath = path.join(modulePath, 'DataTest');
+
+        if (!dataId) {
+            // /modules/:moduleId/test-data - List all test data for a module
+            try {
+                const dataFiles = await fs.promises.readdir(dataTestPath);
+                const jsonDataFiles = dataFiles.filter(file => file.endsWith('.json'));
+
+                const testData = await Promise.all(jsonDataFiles.map(async file => {
+                    const filePath = path.join(dataTestPath, file);
+                    const fileContent = await fs.promises.readFile(filePath, 'utf-8');
+                    return {
+                        id: path.basename(file, '.json'),
+                        ...JSON.parse(fileContent)
+                    };
+                }));
+
+                return res.json(testData);
+            } catch (error) {
+                console.error(`Error reading test data for module ${moduleId}:`, error);
+                return res.status(500).json({ message: `Error reading test data for module ${moduleId}` });
+            }
+        }
+
+        // /modules/:moduleId/test-data/:dataId - Get a specific test data item
+        try {
+            const filePath = path.join(dataTestPath, `${dataId}.json`);
+            const fileContent = await fs.promises.readFile(filePath, 'utf-8');
+            return res.json(JSON.parse(fileContent));
+        } catch (error) {
+            console.error(`Error reading test data item ${dataId} for module ${moduleId}:`, error);
+            return res.status(404).json({ message: `Test data item ${dataId} not found for module ${moduleId}` });
+        }
+    },
+};

--- a/SelfApi/routes/index.js
+++ b/SelfApi/routes/index.js
@@ -9,8 +9,10 @@ const getdiscordAuthurl = require('./get-discordAuthurl.js');
 const post = require('./post-.js');
 
 const putAutorole = require('./put-autorole.js');
+const getModules = require('./get-modules.js');
+const putModuleTestData = require('./put-module-test-data.js');
 
-const routes = [getCommands, postCommands, getEvents, postEvents, getdiscordAuthurl, post, putAutorole];
+const routes = [getCommands, postCommands, getEvents, postEvents, getdiscordAuthurl, post, putAutorole, getModules, putModuleTestData];
 
 /**
  * Enregistre une liste de routes sur l'instance de l'API.

--- a/SelfApi/routes/put-module-test-data.js
+++ b/SelfApi/routes/put-module-test-data.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+    path: /^\/modules\/([^\/]+)\/test-data\/([^\/]+)$/,
+    method: 'put',
+    handler: async (req, res) => {
+        const [, moduleId, dataId] = req.path.match(/^\/modules\/([^\/]+)\/test-data\/([^\/]+)$/);
+        const modulePath = path.join(__dirname, '../../Modules', moduleId);
+        const dataTestPath = path.join(modulePath, 'DataTest');
+        const filePath = path.join(dataTestPath, `${dataId}.json`);
+
+        try {
+            // Check if the file exists
+            await fs.promises.access(filePath);
+
+            // Write the updated data to the file
+            await fs.promises.writeFile(filePath, JSON.stringify(req.body, null, 2));
+
+            res.json({ message: 'Data updated successfully' });
+        } catch (error) {
+            if (error.code === 'ENOENT') {
+                return res.status(404).json({ message: `Test data item ${dataId} not found for module ${moduleId}` });
+            }
+            console.error(`Error updating test data item ${dataId} for module ${moduleId}:`, error);
+            return res.status(500).json({ message: `Error updating test data item ${dataId} for module ${moduleId}` });
+        }
+    },
+};


### PR DESCRIPTION
This commit introduces a new feature that allows users to view and edit test data associated with modules.

- Adds new API endpoints to get modules and their test data, and to update test data.
- Creates a `ModulesList.vue` component to display the list of available modules.
- Creates a `ModuleData.vue` component to display and manage the test data for a specific module.
- Creates a reusable `DataEditor.vue` component for editing JSON data, which can be used for other data types in the future.
- Updates the frontend router to include the new pages.